### PR TITLE
admin is the default admin group on macOSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note: This cookbook does not handle the installation of Java but does require it
 - `node['maven']['setup_bin']` - whether or not to put mvn on your system path, defaults to false
 - `node['maven']['mavenrc']['opts']` - value of `MAVEN_OPTS` environment variable exported via `/etc/mavenrc` template, defaults to `-Dmaven.repo.local=$HOME/.m2/repository -Xmx384m`
 - `node['maven']['user']` - User to own Maven install, defaults to `root` or `Administrator` depending on platform.
-- `node['maven']['group']` - Group to own Maven install, defaults to `root` or `Administrators` depending on platform.
+- `node['maven']['group']` - Group to own Maven install, defaults to `root` for nix, `admin` for macOSX or `Administrators` on windows.
 
 ## Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,6 +38,8 @@ end
 default['maven']['group'] = case node['platform_family']
 when 'windows'
   'Administrators'
+when 'mac_os_x'
+  'admin'
 else
   'root'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Installs Apache Maven includes a resource for installing artifacts from maven'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '5.2.0'
+version          '5.2.1'
 
 depends 'ark',  '>= 1.0'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@ include_recipe 'ark::default'
 
 group 'create the group for Maven' do
   group_name node['maven']['group']
-  not_if { node['maven']['group'] == 'root' || node['maven']['group'] == 'Administrators' }
+  not_if { node['maven']['group'] == 'root' || node['maven']['group'] == 'admin' || node['maven']['group'] == 'Administrators' }
 end
 
 user 'create the user for Maven' do


### PR DESCRIPTION
### Description

Fixes https://github.com/chef-cookbooks/maven/issues/97

### Issues Resolved

https://github.com/chef-cookbooks/maven/issues/97

### Check List

[ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
[ ] New functionality includes testing.
[ ] New functionality has been documented in the README if applicable
[ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
